### PR TITLE
Fixed bugs in digitizer

### DIFF
--- a/PFCalEE/userlib/test/digitizer.cpp
+++ b/PFCalEE/userlib/test/digitizer.cpp
@@ -326,7 +326,6 @@ int main(int argc, char** argv){//main
   unsigned maxSimHits = 0;
   unsigned maxRecHits = 0;
   unsigned maxRecJets = 0;
-  outputTree->Branch("nPuVtx",&nPuVtx);
   HGCSSEvent lEvent;
   outputTree->Branch("HGCSSEvent",&lEvent);
   if (nPU!=0) outputTree->Branch("nPuVtx",&nPuVtx);


### PR DESCRIPTION
bugs have been fixed. The code has been tested with 10 events.
Initially, the seed of lRndm is set to 0:
   pSeed = 0; // default value
  lRndm->SetSeed(pSeed);
Information of the seed will be written into log files.
