### PR TITLE
bugfix in HGCSSDetector

### DIFF
--- a/PFCalEE/userlib/src/HGCSSDetector.cc
+++ b/PFCalEE/userlib/src/HGCSSDetector.cc
@@ -134,13 +134,20 @@ void HGCSSDetector::addSubdetector(const HGCSSSubDetector & adet){
 void HGCSSDetector::finishInitialisation(){
   nSections_ = subdets_.size();
   //indices_.push_back(subdets_[nSections_-1].layerIdMax);
-  unsigned lastEle = indices_.size()-1;
+  const unsigned lastEle = indices_.size()-1;
   nLayers_ = indices_[lastEle];
+
+  unsigned secIndex[lastEle];
+  unsigned iS(0);
+  for(unsigned i(0); i<lastEle ;i++){
+     secIndex[i] = iS;
+     if(indices_[i] < indices_[i+1])iS +=1;
+  }
   //initialise layer-section conversion
   section_.resize(nLayers_,0);
   for (unsigned iL(0); iL<nLayers_;++iL){
     for (unsigned i(0); i<lastEle;++i){
-      if (iL >= indices_[i] && iL < indices_[i+1]) section_[iL] = i;
+      if (iL >= indices_[i] && iL < indices_[i+1]) section_[iL] = secIndex[i];
     }
   }
   printDetector(std::cout);


### PR DESCRIPTION
Create a temporary array "secIndex" to count the section index from 0 up to nSections_.
Before this fixing, when version 31 is used, the "getSection" function returns section=3 or section=4 to "subDetectorByLayer" function, where subdets_ has a size of two and subdets_[3] (or [4]) is not well defined.
This caused a crush in digitizer code.  