### PR TITLE
update to improve the BHCAL segmentations - e.g. 288 segmentations in…

### DIFF
--- a/PFCalEE/userlib/test/digitizer.cpp
+++ b/PFCalEE/userlib/test/digitizer.cpp
@@ -556,8 +556,10 @@ int main(int argc, char** argv){//main
   else if (shape==4) geomConv.initialiseSquareMap(calorSizeXY,10.);
 
   //square map for BHCAL
-  geomConv.initialiseSquareMap1(1.4,3.0,-1.*TMath::Pi(),TMath::Pi(),0.01745);//eta phi segmentation
-  geomConv.initialiseSquareMap2(1.4,3.0,-1.*TMath::Pi(),TMath::Pi(),0.02182);//eta phi segmentation
+  //geomConv.initialiseSquareMap1(1.4,3.0,-1.*TMath::Pi(),TMath::Pi(),0.01745);//eta phi segmentation
+  //geomConv.initialiseSquareMap2(1.4,3.0,-1.*TMath::Pi(),TMath::Pi(),0.02182);//eta phi segmentation
+  geomConv.initialiseSquareMap1(1.4,3.0,-1.*TMath::Pi(),TMath::Pi(),TMath::Pi()*2./360.);//eta phi segmentation
+  geomConv.initialiseSquareMap2(1.4,3.0,-1.*TMath::Pi(),TMath::Pi(),TMath::Pi()*2./288.);//eta phi segmentation
   //geomConv.initialiseSquareMap2(1.4,3.0,0,2*TMath::Pi(),0.02618);//eta phi segmentation
 
   HGCSSDigitisation myDigitiser;


### PR DESCRIPTION
… phi for BHCAL2

Without this change, the HB segmentations are:
*** BHCAL
-- Initialising eta-phi squareMap with parameters: 
---- xmin = 1.4, ymin = -3.14159 side = 0.01745, nx = 91, ny=360
-- Check geomMap: size = 32760
*** BHCAL2
-- Initialising eta-phi squareMap with parameters: 
---- xmin = 1.4, ymin = -3.14159 side = 0.02182, nx = 73, ny=287
-- Check geomMap: size = 20951

For BHCAL2 we expect ∆φ = 1.25 (deg) which corresponds to 288 segmentations (instead of 287) and 287*0.02182 is a little short of 2pi.

This PR is to address this.

Based on email exchange around April 16 (sorry for not making this PR sooner.)

